### PR TITLE
Editor upload image button

### DIFF
--- a/lib/gollum/public/gollum/css/dialog.css
+++ b/lib/gollum/public/gollum/css/dialog.css
@@ -251,3 +251,8 @@
   background: -webkit-gradient(linear, left top, left bottom, from(#599bdc), to(#3072b3));
   background: -moz-linear-gradient(top, #599bdc, #3072b3);
 }
+
+#gollum-dialog-dialog a.dialogminibutton {
+  float: left;
+  margin-left: 0;
+}

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -110,6 +110,34 @@
           $editorBody.removeClass('dragging');
           return false;
         };
+        editorBody.uploadFile = function(id, field) {
+          debug("uploading file from button");
+    
+          var file = $("#" + id)[0].files[0],
+          formData = new FormData();
+          formData.append('upload_dest', uploadDest);
+          formData.append('file', file);
+
+          $.ajax({
+            url: baseUrl + '/uploadFile',
+            data: formData,
+            cache: false,
+            contentType: false,
+            processData: false,
+            type: 'POST',
+            success: function(){
+              var text = '[[/' + uploadDest + '/' + file.name + ']]';
+              if (field) {
+                $(field).val(text);
+              }
+            },
+            error: function(r, textStatus) {
+              alert('Error uploading file: ' + textStatus);
+	    }
+          });
+			
+          return false;
+        };
         editorBody.ondrop = function(e) {
           debug("dropped file");
           e.preventDefault();

--- a/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
+++ b/lib/gollum/public/gollum/javascript/editor/langs/markdown.js
@@ -115,20 +115,31 @@ var MarkDown = {
   'function-image'      :   {
                               exec: function( txt, selText, $field ) {
                                 var results = null;
+				var fields = [
+                                  {
+                                    id: 'url',
+                                    name: 'Image URL',
+                                    type: 'text'
+                                  },
+                                  {
+                                    id: 'alt',
+                                    name: 'Alt Text',
+                                    type: 'text'
+                                  }
+                                ];
+				if (filesApiSupported) {
+				  fields.push( 
+				  {
+				    id: 'image-upload',
+				    name: 'image-upload',
+				    type: 'file',
+				    target: '#gollum-editor-body',
+				    url: '#gollum-dialog-dialog-generated-field-url'
+				   });
+				}
                                 $.GollumEditor.Dialog.init({
                                   title: 'Insert Image',
-                                  fields: [
-                                    {
-                                      id: 'url',
-                                      name: 'Image URL',
-                                      type: 'text'
-                                    },
-                                    {
-                                      id: 'alt',
-                                      name: 'Alt Text',
-                                      type: 'text'
-                                    }
-                                  ],
+                                  fields: fields,
                                   OK: function( res ) {
                                     var rep = '';
                                     if ( res['url'] && res['alt'] ) {
@@ -142,6 +153,13 @@ var MarkDown = {
                             }
 
 };
+
+var filesApiSupported = (function(undefined) {
+  return $("<input type='file'>")    
+          .get(0)               
+          .files !== undefined; 
+})();
+
 
 var MarkDownHelp = [
 

--- a/lib/gollum/public/gollum/javascript/gollum.dialog.js
+++ b/lib/gollum/public/gollum/javascript/gollum.dialog.js
@@ -48,7 +48,7 @@
             break;
 
           case 'file':
-            fieldMarkup += Dialog.createFieldFile( fieldArray[i] );
+            fieldMarkup += Dialog.createFieldFile( fieldArray[i], fieldArray[i].target, fieldArray[i].url );
             break;
 
           default:
@@ -95,21 +95,25 @@
       return html;
     },
 
-    createFieldFile: function( fieldAttributes ) {
+    createFieldFile: function( fieldAttributes, elementId, url ) {
       // Not actually a field, but an embedded form.
       var html = '';
 
       var id = fieldAttributes.id || 'upload';
       var name = fieldAttributes.name || 'file';
       var action = fieldAttributes.action || '/uploadFile';
-
+      var target = '$(\'' + elementId + '\')[0].uploadFile(\'' + id + '\', \'' + url + '\')';
+	 
       html += '<form method=post enctype="multipart/form-data" ' +
-        'action="' + action + '" ' + 'id="' + id + '">';
-      html += '<input type="hidden" name="upload_dest" value="' +
-        uploadDest + '">';
-      html += '<input type=file name="' + name + '">';
+        'action="' + action + '" ' + 'id="' + id + '-form">';
+      html += '<a id="' + id + '-button" href="javascript:$(\'#' + id + '\').click();" ' + 
+        ' class="minibutton dialogminibutton">'
+      html += 'Upload Image</a><input type="hidden" name="upload_dest" value="' +
+      	uploadDest + '">';
+      html += '<input type=file name="' + name + '" id="' + id + '" style="display: none;"' + 
+        ' onChange="' + target + '" />';
       html += '</form>';
-
+	  
       if( fieldAttributes.context ){
         html += '<span class="context">' + fieldAttributes.context + '</span>';
       }


### PR DESCRIPTION
Adding a button to the insert image dialog in the markdown editor to allow the user to upload a file.

This exposes the drag and drop functionality that Gollum already had.  When a user uploads a file in the insert image dialog, the resulting file location will be copied to the URL field.  Uploads must be enabled and the upload button will upload the files to the same location as the drag and drop interface does.
